### PR TITLE
ww/chats: updating websocket logic to handle DB and pub/sub interactions

### DIFF
--- a/pubsub/broker.go
+++ b/pubsub/broker.go
@@ -53,10 +53,10 @@ func (b *Broker) Broadcast(msg string, topics []string) {
 	}
 }
 
-func (b *Broker) GetSubscribers(topic string) int {
+func (b *Broker) GetSubscribers(topic string) Subscribers {
 	b.mut.RLock() // whats the diff with .Lock()? whats recursive read locking?
 	defer b.mut.RUnlock()
-	return len(b.topics[topic])
+	return b.topics[topic] // why was this len()????
 }
 
 func (b *Broker) Subscribe(s *Subscriber, topic string) {

--- a/pubsub/subscriber.go
+++ b/pubsub/subscriber.go
@@ -22,7 +22,7 @@ func CreateNewSubscriber(user_uuid string) (string, *Subscriber) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	//instead of making this, you will pass uuid from websocket
+	//instead of making this id, you will pass uuid from websocket
 	// id := fmt.Sprintf("%X-%X", b[0:4], b[4:8])
 	id := user_uuid
 	return id, &Subscriber{

--- a/queries/chat.go
+++ b/queries/chat.go
@@ -120,6 +120,8 @@ func CreateChatPreviewsByUserID(userId string) ([]types.PreviewMessage, error) {
 	// ids := "'" + strings.Join(chatRoomIDs, "','") + "'"
 
 	// Construct the query string
+	//please study this in more depth
+	// ?is this query time bad compared to multiple joins?
 	query := fmt.Sprintf(`
 	WITH recent_messages AS (
     SELECT DISTINCT ON (chat_room_id) *

--- a/types/websocket.go
+++ b/types/websocket.go
@@ -1,0 +1,13 @@
+package types
+
+type WebSocketMessage struct {
+	Action      string `json:"action"`
+	ChatRoom_ID string `json:"chat_room_id"`
+	User_ID     string `json:"user_id"`
+	Content     string `json:"content"`
+}
+
+type ResponseBody struct {
+	Message
+	Action string `json:"action"`
+}

--- a/websockets/client.go
+++ b/websockets/client.go
@@ -131,7 +131,8 @@ func serveWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userId := r.Header.Get("user_id")
+	userId := r.URL.Query().Get("user_id")
+	// userId := r.Header.Get("user_id")
 	client := &Client{hub: hub, conn: conn, send: make(chan []byte, 256), id: userId}
 	client.hub.register <- client
 

--- a/websockets/hub.go
+++ b/websockets/hub.go
@@ -113,24 +113,19 @@ func (h *Hub) run() {
 			default:
 				fmt.Println("default fired")
 			}
-
+			getSubscribers := broker.GetSubscribers(responseBody.ChatRoom_ID)
 			for client := range h.clients {
-				// println("test id, ", client.id)
-				/*
-				 - check for topic by message id
-				 - if not exist - make topic
-				 then
-				 subscribe user to topic
-				*/
-				// if responseBody.Chatroom_ID
-
-				select {
-				case client.send <- message:
-				default:
-					close(client.send)
-					delete(h.clients, client)
-					// DESTROY pubsub
+				// check if client is a subscriber
+				if _, ok := getSubscribers[client.id]; ok {
+					select {
+					case client.send <- message:
+					default:
+						close(client.send)
+						delete(h.clients, client)
+						// DESTROY pubsub?
+					}
 				}
+
 			}
 		}
 	}


### PR DESCRIPTION
This allows users to send messages privately to their respective chat rooms, instead of all websockets being broadcasted globally to all subscribers 

<img width="1003" alt="Screenshot 2024-02-23 at 9 35 42 AM" src="https://github.com/willybeans/freedu_go/assets/20260208/c03c067a-0ce9-4c04-8851-d863be35289d">

here we can see that user 1 (johnny_mnemonic) receives 2 messages, 1 from himself(to user2) and one from user 3 (twinkle_toes), but user 3 only receives the 1 from himself and is restricted from seeing that other message

<img width="1020" alt="Screenshot 2024-02-23 at 9 37 07 AM" src="https://github.com/willybeans/freedu_go/assets/20260208/a09807b3-8d6d-4c9d-b28a-7cf986435e93">
